### PR TITLE
Docs: Update documentation for Docker users

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM odoo:18
 
+# Explicitly set shell to the default /bin/sh -c for broader compatibility
+# This can help avoid issues with base image SHELL instructions when building for OCI format.
+SHELL ["/bin/sh", "-c"]
+
 USER root
 RUN apt-get update && apt-get install -y gettext gsfonts fontconfig libfreetype6 fonts-freefont-ttf fonts-dejavu && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Updated README.md, setup.sh, and VSCode-Podman-Guide.md to be more inclusive for Docker users.

- Provided Docker command equivalents where Podman commands were listed.
- Modified setup.sh to auto-detect podman-compose or docker-compose.
- Generalized terminology to refer to 'containers' rather than being Podman-specific.

Fix: Explicitly set SHELL in Dockerfile

Added SHELL ["/bin/sh", "-c"] to Dockerfile to potentially mitigate warnings about SHELL incompatibility with OCI image format during Docker builds by overriding any complex SHELL instruction from the base image.