### PR TITLE
Build: Set BUILDAH_FORMAT=docker in setup.sh for podman rebuilds & up…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM odoo:18
 
-# Explicitly set shell to the default /bin/sh -c for broader compatibility
+# Explicitly set shell to the default /bin/sh -c for broader compatibility,
+# immediately after FROM to override any base image SHELL settings early.
 # This can help avoid issues with base image SHELL instructions when building for OCI format.
 SHELL ["/bin/sh", "-c"]
 
@@ -14,4 +15,4 @@ RUN if [ -f /tmp/requirements.txt ]; then pip3 install --break-system-packages -
 COPY start-debugpy.sh /start-debugpy.sh
 RUN chmod +x /start-debugpy.sh
 
-USER odoo 
+USER odoo

--- a/README.md
+++ b/README.md
@@ -483,6 +483,16 @@ Docker Desktop users should configure resources via the Docker Desktop GUI setti
    - Check machine configuration: `podman machine inspect`
    - Reinitialize machine if needed with proper volume flags
 
+7. **OCI Format Warnings with Podman Builds**:
+   - If you encounter warnings related to "OCI image format" when building images with Podman (e.g., via `podman-compose build`), this might be due to the base image or specific instructions conflicting with strict OCI format expectations.
+   - **Podman Tip:** The `./setup.sh rebuild` command now attempts to automatically set `BUILDAH_FORMAT=docker` when using `podman-compose` to help avoid these warnings by forcing the Docker v2 image format.
+   - If you are running `podman-compose build` manually and see these warnings, you can try:
+     ```bash
+     export BUILDAH_FORMAT=docker
+     podman-compose build --no-cache
+     ```
+   - This setting is specific to the Podman build process (Buildah engine). Docker users typically do not need this.
+
 ### Debug Commands
 
 (Replace `podman` with `docker` if using Docker)

--- a/setup.sh
+++ b/setup.sh
@@ -40,7 +40,16 @@ function start_env() {
 
 function rebuild_env() {
   echo -e "${green}Rebuilding Docker image and starting Odoo 18 development environment...${reset}"
-  ${COMPOSE_CMD} build --no-cache
+
+  if [ "${COMPOSE_CMD}" = "podman-compose" ]; then
+    echo -e "${green}Podman detected, setting BUILDAH_FORMAT=docker for build to potentially avoid OCI warnings.${reset}"
+    export BUILDAH_FORMAT=docker
+    ${COMPOSE_CMD} build --no-cache
+    unset BUILDAH_FORMAT # Unset after build to not affect other potential podman commands
+  else
+    ${COMPOSE_CMD} build --no-cache
+  fi
+
   ${COMPOSE_CMD} up -d
   echo -e "${green}Odoo should be available at http://localhost:${ODOO_PORT}${reset}"
 }


### PR DESCRIPTION
…date docs

- Modified setup.sh to conditionally export BUILDAH_FORMAT=docker during the rebuild_env function when podman-compose is used. This aims to proactively mitigate OCI format warnings for Podman users.
- Updated README.md to reflect this change in setup.sh and to clarify when manual export of BUILDAH_FORMAT might still be relevant for Podman users.